### PR TITLE
Configurable number of parameters and save/restore loop.

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -393,4 +393,4 @@ allow_split_physical_axes: False
 
 # Attributes needed for the MaxText checkpointing loop using standalone_checkpointer.
 gcs_metrics_bucket: distributed-checkpointing-metrics
-step_time_seconds: 0.0
+per_step_interval: 0.0

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -393,3 +393,4 @@ allow_split_physical_axes: False
 
 # Attributes needed for the MaxText checkpointing loop using standalone_checkpointer.
 gcs_metrics_bucket: distributed-checkpointing-metrics
+step_time_seconds: 0.0

--- a/MaxText/configs/v5e/64b.sh
+++ b/MaxText/configs/v5e/64b.sh
@@ -27,6 +27,10 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# Use 64b parameters if not set.
+PARAMETERS="${PARAMETERS:-64}"
+echo "Using ${PARAMETERS}b parameters"
+
 # The setup accommodates two cases:
 # 1) Passing the 'RUN_NAME' variable at runtime
 # 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
@@ -43,10 +47,11 @@ export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xl
 JAX_PLATFORMS=cpu python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=$STEPS checkpoint_period=$CHECKPOINT_PERIOD per_device_batch_size=1 enable_checkpointing=true\
     async_checkpointing=false\
-    remat_policy=full global_parameter_scale=64\
+    remat_policy=full global_parameter_scale=$PARAMETERS\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     hardware=$HARDWARE\
     use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic attention='flash' gcs_metrics=true\
     load_full_state_path=$PREVIOUS_STATE\
-    gcs_metrics_bucket=$GCS_METRICS_BUCKET
+    gcs_metrics_bucket=$GCS_METRICS_BUCKET\
+    step_time_seconds=$STEP_TIME_SECONDS

--- a/MaxText/configs/v5e/64b.sh
+++ b/MaxText/configs/v5e/64b.sh
@@ -54,4 +54,4 @@ JAX_PLATFORMS=cpu python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     dataset_type=synthetic attention='flash' gcs_metrics=true\
     load_full_state_path=$PREVIOUS_STATE\
     gcs_metrics_bucket=$GCS_METRICS_BUCKET\
-    step_time_seconds=$STEP_TIME_SECONDS
+    per_step_interval=$PER_STEP_INTERVAL


### PR DESCRIPTION
This adds the following features to the gcs-checkpointing setup:
- Configurable number of parameters by setting the $PARAMETERS env variable
- Reloads all checkpoints immediately after saving them
- Adds a configurable minimum step time (when saving checkpoints)